### PR TITLE
Add a Makefile with convenience install, test, clean commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /dist
 /build
 /docs/_build
+venv

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ clean:
 	rm -rf venv *.egg
 
 install: venv
-	. venv/bin/activate; python setup.py install
+	. venv/bin/activate; python setup.py develop
+	. venv/bin/activate; pip install -r test-requirements.txt --use-mirrors
 
 test:
-	python setup.py test
+	nosetests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY : venv clean install test
+.PHONY : venv clean install test docs
 
 venv:
 	virtualenv venv
@@ -12,3 +12,7 @@ install: venv
 
 test:
 	. venv/bin/activate; nosetests
+
+docs:
+	. venv/bin/activate; pip install sphinx
+	cd docs && make html

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY : venv clean install test
+
+venv:
+	virtualenv venv
+
+clean: 
+	rm -rf venv *.egg
+
+install: venv
+	. venv/bin/activate; python setup.py install
+
+test:
+	python setup.py test

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ clean:
 	rm -rf venv *.egg
 
 install: venv
-	. venv/bin/activate; python setup.py develop
 	. venv/bin/activate; pip install -r test-requirements.txt --use-mirrors
+	. venv/bin/activate; python setup.py develop
 
 test:
-	nosetests
+	. venv/bin/activate; nosetests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,3 @@
 nose==1.3
 tornado==2.4.1
 coverage==3.6
-ndg-httpsclient
-pyasn1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
 nose==1.3
 tornado==2.4.1
 coverage==3.6
+ndg-httpsclient
+pyasn1


### PR DESCRIPTION
This lets developers install urllib3 locally by running "make install" and to run the tests by running "make test". 

I also had to add two packages to test-requirements.txt to get the requirements file working on my local machine (a Mac running 10.8, and Homebrew python 2.7). I'm possibly missing something in the way the tests should be run however.
